### PR TITLE
[F] homepage gem URL.

### DIFF
--- a/ruby_cowsay.gemspec
+++ b/ruby_cowsay.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["patricktulskie@gmail.com"]
   gem.summary       = %q{Cowsay, written in ruby, as a gem.}
   gem.description   = %q{Cowsay, written in ruby, as a gem.}
-  gem.homepage      = %q{http://github.com/PatrickTulskie/cowsay}
+  gem.homepage      = %q{https://github.com/PatrickTulskie/ruby_cowsay}
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
HOMEPAGE link from https://rubygems.org/gems/ruby_cowsay is broken.
Suggest updating it, to make it easier to locate the github repository.

Thanks for this gem. :-)

PD: Could you also include a free license to the project/gem?
